### PR TITLE
CoreData Property Changes and Fixed Crashes

### DIFF
--- a/ESet+CoreDataProperties.swift
+++ b/ESet+CoreDataProperties.swift
@@ -17,26 +17,26 @@ extension ESet {
     }
 
     @NSManaged public var set: Int16
-    @NSManaged public var rpe: Int16
-    @NSManaged public var weight: Double
+    @NSManaged public var rpe: String?
+    @NSManaged public var weight: String?
     @NSManaged public var isComplete: Bool
     @NSManaged public var exercise: Exercise?
-    @NSManaged public var reps: Int16
+    @NSManaged public var reps: String?
     
     public var strSet: String {
         String(set)
     }
     public var strRpe: String {
-        get {String(rpe)}
-        set {rpe = Int16(newValue) ?? 0}
+        get {rpe ?? "11"}
+        set {self.rpe = newValue}
     }
     public var strWeight: String {
-        get {String(weight)}
-        set {weight = Double(newValue) ?? 0}
+        get {weight ?? "111.11"}
+        set {self.weight = newValue}
     }
     public var strReps: String {
-        get {String(reps)}
-        set {reps = Int16(newValue) ?? 0}
+        get { reps ?? "11"}
+        set {self.reps = newValue}
     }
     
 

--- a/Iron.xcdatamodeld/Iron.xcdatamodel/contents
+++ b/Iron.xcdatamodeld/Iron.xcdatamodel/contents
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21223.11" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ESet" representedClassName="ESet" syncable="YES">
         <attribute name="isComplete" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="reps" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="rpe" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="reps" optional="YES" attributeType="String"/>
+        <attribute name="rpe" optional="YES" attributeType="String"/>
         <attribute name="set" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="weight" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="exercise" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Exercise" inverseName="eSet" inverseEntity="Exercise"/>
     </entity>
     <entity name="Exercise" representedClassName="Exercise" syncable="YES">

--- a/Iron/Views/AddExerciseView.swift
+++ b/Iron/Views/AddExerciseView.swift
@@ -13,7 +13,7 @@ struct AddExerciseView: View {
     
     @State private var exerciseName = ""
     
-    let exercise: Exercise
+    let workout: Workout
     var body: some View {
         Form {
             TextField("Exercise Name", text: $exerciseName)
@@ -24,14 +24,14 @@ struct AddExerciseView: View {
     func addExercise (name: String) {
         let newExercise = Exercise(context: moc)
         newExercise.name = name
-        newExercise.workout = exercise.workout
+        newExercise.workout = workout
         
         let defaultSet = ESet(context: moc)
         defaultSet.exercise = newExercise
         defaultSet.set = 1
-        defaultSet.weight = 45.0
-        defaultSet.reps = 6
-        defaultSet.rpe = 8
+        defaultSet.weight = "45.0"
+        defaultSet.reps = "6"
+        defaultSet.rpe = "8"
         defaultSet.isComplete = false
         
         PersistenceController.shared.save()

--- a/Iron/Views/AddWorkoutView.swift
+++ b/Iron/Views/AddWorkoutView.swift
@@ -38,9 +38,9 @@ struct AddWorkoutView: View {
         let defaultSet = ESet(context: moc)
         defaultSet.exercise = newExercise
         defaultSet.set = 1
-        defaultSet.weight = 45.0
-        defaultSet.reps = 6
-        defaultSet.rpe = 8
+        defaultSet.weight = "45.0"
+        defaultSet.reps = "6"
+        defaultSet.rpe = "8"
         defaultSet.isComplete = false
         PersistenceController.shared.save()
         dismiss()

--- a/Iron/Views/ExerciseView.swift
+++ b/Iron/Views/ExerciseView.swift
@@ -28,7 +28,7 @@ struct ExerciseView: View {
         }
         .navigationTitle("Exercises")
         .sheet(isPresented: $showingSheet) {
-            AddExerciseView(exercise: workout.exerciseArray[0])
+            AddExerciseView(workout: workout)
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/Iron/Views/SetView.swift
+++ b/Iron/Views/SetView.swift
@@ -46,7 +46,7 @@ struct SetView: View {
             }
 
         }
-        .navigationTitle(exercise.eSetArray[0].exercise?.wrappedName ?? "Unknown Exercise Name")
+        .navigationTitle(exercise.wrappedName)
         
     }
     func removeRows(at offsets: IndexSet) {
@@ -59,14 +59,20 @@ struct SetView: View {
     }
     func addSet() {
         let newSet = ESet(context: moc)
-        let count = exercise.eSetArray.count
-        let lastSet = exercise.eSetArray[count - 1]
+        let setCount = exercise.eSetArray.count
         
-        newSet.set = Int16(count + 1)
+        if setCount > 0 { //If there is a previous set to copy, copy it
+            let lastSet = exercise.eSetArray[setCount - 1]
+            newSet.reps = lastSet.reps
+            newSet.weight = lastSet.weight
+            newSet.rpe = lastSet.rpe
+        } else { // otherwise use default values
+            newSet.reps = "5"
+            newSet.weight = "45.0"
+            newSet.rpe = "7"
+        }
         
-        newSet.reps = lastSet.reps
-        newSet.weight = lastSet.weight
-        newSet.rpe = lastSet.rpe
+        newSet.set = Int16(setCount + 1)
         newSet.isComplete = false
         newSet.exercise = exercise.eSetArray[0].exercise
         PersistenceController.shared.save()


### PR DESCRIPTION
Changed most ESet fields to Strings to prevent issues when typing in values. Will implement validation on front-end. Fixed issues with how I was passing workout/exercise objects. App will no longer crash when no exercise/set can be found.